### PR TITLE
Add unit test to ensure TensorFlow utilizes GPU whenever supported ha…

### DIFF
--- a/tests/test_separator.py
+++ b/tests/test_separator.py
@@ -138,3 +138,20 @@ def test_filename_conflict(test_file, configuration):
                 test_file,
                 directory,
                 filename_format='I wanna be your lover')
+
+@pytest.mark.parametrize('test_file', TEST_AUDIO_DESCRIPTORS)
+def test_tensorflow_uses_gpu(test_file):
+    adapter = AudioAdapter.default()
+    waveform, _ = adapter.load(test_file)
+
+    if not tf.config.list_physical_devices('GPU'):
+        assert True
+
+    try:
+        with tf.device('/gpu:0'):
+            separator_tf = Separator(
+                "spleeter:2stems", stft_backend="tensorflow", multiprocess=False)
+            separator_tf._separate_tensorflow(waveform, test_file)
+
+    except Exception as e:
+        assert False


### PR DESCRIPTION
# Add unit test to ensure TensorFlow utilizes GPU whenever supported hardware is present

- [x] I read [contributing guideline](https://github.com/deezer/spleeter/blob/master/.github/CONTRIBUTING.md)
- [x] I didn't find a similar pull request already open.
- [x] My PR is related to Spleeter only, not a derivative product (such as Webapplication, or GUI provided by others)

## Description
Created unit test to verify that TensorFlow utilizes GPU acceleration when specified as the backend.

## How this patch was tested
Added new unit test to `separator.py` and ran Pytest.

You tested it, right?

- [x] I implemented unit test whicn ran successfully using `poetry run pytest tests/`
- [x] Code has been formatted using `poetry run black spleeter`
- [x] Imports has been formatted using `poetry run isort spleeter``

## Documentation link and external references

Please provide any info that may help us better understand your code.
