### PR TITLE
Test that "auto" / no specified backend resolves to TensorFlow on supported hardware

### DIFF
--- a/tests/test_separator.py
+++ b/tests/test_separator.py
@@ -145,6 +145,8 @@ def test_auto_backend_resolves_to_tensorflow():
     if not tf.config.list_physical_devices('GPU'):
         assert True
 
+    separator_tf = Separator("spleeter:2stems", multiprocess=False)
+    assert separator_tf._params["stft_backend"] == "tensorflow"
     separator_tf = Separator("spleeter:2stems", stft_backend="auto", multiprocess=False)
     assert separator_tf._params["stft_backend"] == "tensorflow"
 

--- a/tests/test_separator.py
+++ b/tests/test_separator.py
@@ -139,8 +139,18 @@ def test_filename_conflict(test_file, configuration):
                 directory,
                 filename_format='I wanna be your lover')
 
+
+def test_auto_backend_resolves_to_tensorflow():
+    
+    if not tf.config.list_physical_devices('GPU'):
+        assert True
+
+    separator_tf = Separator("spleeter:2stems", stft_backend="auto", multiprocess=False)
+    assert separator_tf._params["stft_backend"] == "tensorflow"
+
+
 @pytest.mark.parametrize('test_file', TEST_AUDIO_DESCRIPTORS)
-def test_tensorflow_uses_gpu(test_file):
+def test_tensorflow_on_gpu(test_file):
     adapter = AudioAdapter.default()
     waveform, _ = adapter.load(test_file)
 


### PR DESCRIPTION
# Test that "auto" / no specified backend resolves to TensorFlow on supported hardware

- [x] I read [contributing guideline](https://github.com/deezer/spleeter/blob/master/.github/CONTRIBUTING.md)
- [x] I didn't find a similar pull request already open.
- [x] My PR is related to Spleeter only, not a derivative product (such as Webapplication, or GUI provided by others)

## Description

When "auto" or no backend is specified on the separate function, this argument should resolve to "tensorflow" on supported hardware. This PR adds a unit test to validate this.

## How this patch was tested

Added unit test to `test_separator.py` and ran PyTest.

- [x] I implemented unit test whicn ran successfully using `poetry run pytest tests/`
- [x] Code has been formatted using `poetry run black spleeter`
- [x] Imports has been formatted using `poetry run isort spleeter``

## Documentation link and external references

Please provide any info that may help us better understand your code.
